### PR TITLE
fix(deps): remove duplicate PyYAML version in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,6 +10,5 @@ pandas==2.0.1
 psutil==5.9.6
 pycryptodome==3.19.0
 pywin32==306
-PyYAML==6.0.1
 PyYAML==6.0.2
 tqdm==4.62.3


### PR DESCRIPTION
Removed duplicate PyYAML==6.0.1 to fix dependency conflict during installation.
